### PR TITLE
Improvement to entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ then
 else
   ## Clone the target repository
   git clone "$REPOSITORY_PATH" $DOC_FOLDER --branch $BRANCH --single-branch && \
-  cd $DOC_FOLDER \
+  cd $DOC_FOLDER
 fi
 
 # Checks out the base branch to begin the deploy process.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,11 @@ then
   exit 1
 fi
 
+if [ -z "$DOC_FOLDER" ];
+then
+  DOC_FOLDER=$BRANCH
+fi
+
 if [ -z "$FOLDER" ]
 then
   echo "You must provide the action with the folder name in the repository where your compiled page lives."
@@ -57,22 +62,24 @@ git config --global user.name "${COMMIT_NAME}" && \
 ## Initializes the repository path using the access token.
 REPOSITORY_PATH="https://${GH_TOKEN}@github.com/${TARGET_REPOSITORY}.git" && \
 
-## Clone the target repository
-git clone "$REPOSITORY_PATH" docs && \
-cd docs \
-
 # Checks to see if the remote exists prior to deploying.
 # If the branch doesn't exist it gets created here as an orphan.
 if [ "$(git ls-remote --heads "$REPOSITORY_PATH" "$BRANCH" | wc -l)" -eq 0 ];
 then
   echo "Creating remote branch ${BRANCH} as it doesn't exist..."
-  git checkout "${BASE_BRANCH}" && \
-  git checkout --orphan $BRANCH && \
-  git rm -rf . && \
+  mkdir $DOC_FOLDER && \
+  cd $DOC_FOLDER && \
+  git init && \
+  git checkout -b $BRANCH && \
+  git remote add origin $REPOSITORY_PATH && \
   touch README.md && \
   git add README.md && \
   git commit -m "Initial ${BRANCH} commit" && \
   git push $REPOSITORY_PATH $BRANCH
+else
+  ## Clone the target repository
+  git clone "$REPOSITORY_PATH" $DOC_FOLDER --branch $BRANCH --single-branch && \
+  cd $DOC_FOLDER \
 fi
 
 # Checks out the base branch to begin the deploy process.


### PR DESCRIPTION
**Description**
This action does not work properly in the case of [grails/grom-hibernate5](https://github.com/grails/gorm-hibernate5) because there is already a docs folder in the project. So, with the flexibility to pass the name of the documentation folder we should be able to solve this problem.

In addition, I think we only need to clone gh-pages branch instead of cloning the whole repository. 
